### PR TITLE
show partial output when evaluate

### DIFF
--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -142,6 +142,9 @@ def main():
 
     with torch.no_grad():
         for step, batch in enumerate(eval_dataloader):
+            if step == 0:
+                vae_wrapper.add_hook(args.output_dir)
+
             pixel_values = batch.get("pixel_values")
             if pixel_values is None:
                 continue
@@ -191,6 +194,8 @@ def main():
             current_avg_mse = total_mse / num_batches if num_batches > 0 else 0
             current_avg_kl = total_kl / num_batches if num_batches > 0 else 0
             progress_bar.set_postfix(MSE=f"{current_avg_mse:.4e}", KL=f"{current_avg_kl:.4e}")
+
+            vae_wrapper.remove_hook()
 
 
     # --- Final Metrics ---

--- a/src/train.py
+++ b/src/train.py
@@ -36,7 +36,7 @@ warnings.filterwarnings("ignore", category=UserWarning)
 
 # target layers for dead neuron analysis (based on user code)
 target_layer_classes = (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Conv3d, torch.nn.Linear)
-target_layer_names = ["decoder.conv_out.weight", "decoder.conv_in.weight"]
+target_layer_names = ["encoder.down_blocks.1.resnets.0.conv_shortcut.weight"]
 
 def parse_args():
     """Parses command-line arguments."""


### PR DESCRIPTION
add utilities to save image of intermediate results of encoder resnet layer on the first batch of evaluate dataset. might need to have a limit on the count when batch size is large.

- also update to track encoder down block layer instead, since this one appears to have increasing dead neurons